### PR TITLE
tokenzing opacity for states (Hover and disabled) and creating an overlay effect on hover and active states

### DIFF
--- a/src/Components/Button/Button.scss
+++ b/src/Components/Button/Button.scss
@@ -26,17 +26,7 @@
   }
 
   &:after {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    content: '';
-    z-index: -1;
-    border-radius: $cf-radius;
-    transition: opacity $cf-transition-default;
-    opacity: 0;
-    background-color: #ffffff;
+   @include createOverlayBase();
   }
 
   &:hover {

--- a/src/Components/Button/Button.scss
+++ b/src/Components/Button/Button.scss
@@ -36,6 +36,7 @@
     border-radius: $cf-radius;
     transition: opacity $cf-transition-default;
     opacity: 0;
+    background-color: #ffffff;
   }
 
   &:hover {
@@ -150,8 +151,6 @@
 @mixin buttonColorModifier(
   $bgA,
   $bgB,
-  $bgHoverA,
-  $bgHoverB,
   $text,
   $textHover,
   $tertiary: false
@@ -159,16 +158,12 @@
   color: $text;
   @include gradient-diag-up($bgA, $bgB);
 
-  &:after {
-    @include gradient-diag-up($bgHoverA, $bgHoverB);
-  }
-
   &:hover {
     color: $textHover;
   }
 
   &:hover:after {
-    opacity: 1;
+    opacity: $cf-hover-active-opacity;
   }
 
   &:focus {
@@ -187,7 +182,7 @@
     &:focus,
     &.active:hover {
       &:after {
-        opacity: 1;
+        opacity: $cf-hover-active-opacity;
       }
     }
   } @else {
@@ -199,7 +194,7 @@
       color: $textHover;
 
       &:after {
-        opacity: 1;
+        opacity: $cf-hover-active-opacity;
       }
     }
   }
@@ -217,7 +212,7 @@
   &.cf-button--disabled:hover,
   &.cf-button--disabled:focus {
     cursor: not-allowed;
-    opacity: 0.5;
+    opacity: $cf-disabled-opacity;
   }
 
   .cf-button-spinner {
@@ -230,8 +225,6 @@
   @include buttonColorModifier(
     $cf-grey-15,
     $cf-grey-15,
-    $cf-grey-5,
-    $cf-grey-5,
     $g15-platinum,
     $g20-white
   );
@@ -240,16 +233,12 @@
   @include buttonColorModifier(
     #0098f0,
     #8e1fc3,
-    #0098f0,
-    #8e1fc3,
     $g20-white,
     $g20-white
   );
 }
 .cf-button-secondary {
   @include buttonColorModifier(
-    $cf-grey-45,
-    $cf-grey-45,
     $cf-grey-35,
     $cf-grey-35,
     $g20-white,
@@ -260,8 +249,6 @@
   @include buttonColorModifier(
     transparent,
     transparent,
-    $g3-castle,
-    $g3-castle,
     $g9-mountain,
     $g20-white,
     true
@@ -271,8 +258,7 @@
   @include buttonColorModifier(
     #02714a,
     #50cb70,
-    #02714a,
-    #50cb70,
+
     $g20-white,
     $g20-white
   );
@@ -281,8 +267,7 @@
   @include buttonColorModifier(
     $c-topaz,
     $c-pineapple,
-    $c-thunder,
-    $c-daisy,
+
     $g4-onyx,
     $g4-onyx
   );
@@ -291,8 +276,7 @@
   @include buttonColorModifier(
     #e85b1c,
     #bf3d5e,
-    #e85b1c,
-    #bf3d5e,
+
     $g20-white,
     $g20-white
   );

--- a/src/Components/IndexList/IndexList.scss
+++ b/src/Components/IndexList/IndexList.scss
@@ -35,8 +35,21 @@ $cf-index-list--sort-text: $g11-sidewalk;
   color: $cf-card-text--default;
   display: flex;
   align-items: center;
-  transition: background-color $cf-transition-default,
+  transition: opacity $cf-transition-default,
     color $cf-transition-default;
+
+  &:after {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    content: '';
+    border-radius: $cf-radius;
+    transition: opacity $cf-transition-default;
+    opacity: 0;
+    background-color: #ffffff;
+    }
 }
 
 // Alignment modifiers
@@ -78,12 +91,15 @@ $cf-index-list--sort-text: $g11-sidewalk;
 // Row Style
 .cf-index-list--row {
   @extend %panel-shadow;
+  position: relative;
 }
 
 // Row hover State
 .cf-index-list--row:hover .cf-index-list--cell {
-  background-color: $cf-card-background--hover;
   color: $cf-card-text--hover;
+  &:after {
+    opacity: $cf-hover-active-opacity;
+  }
 }
 
 // Show cell contents on row hover
@@ -128,7 +144,11 @@ $cf-index-list--sort-text: $g11-sidewalk;
   background-color: $cf-card-background--disabled;
   color: $cf-card-text--disabled;
   cursor: not-allowed;
-  opacity: 0.5;
+  opacity: $cf-disabled-opacity;
+  
+  &:after{
+    opacity: 0;
+  }
 
   a:link,
   a:visited,

--- a/src/Components/IndexList/IndexList.scss
+++ b/src/Components/IndexList/IndexList.scss
@@ -39,16 +39,7 @@ $cf-index-list--sort-text: $g11-sidewalk;
     color $cf-transition-default;
 
   &:after {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    content: '';
-    border-radius: $cf-radius;
-    transition: opacity $cf-transition-default;
-    opacity: 0;
-    background-color: #ffffff;
+    @include createOverlayBase();
     }
 }
 

--- a/src/Components/SelectGroup/SelectGroup.scss
+++ b/src/Components/SelectGroup/SelectGroup.scss
@@ -48,16 +48,7 @@ $select-group--padding: $cf-marg-a;
   position:relative;
 
   &:after {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    content: '';
-    border-radius: $cf-radius;
-    transition: opacity $cf-transition-default;
-    opacity: 0;
-    background-color: #ffffff;
+    @include createOverlayBase();
   }
 
   &:last-child {

--- a/src/Components/SelectGroup/SelectGroup.scss
+++ b/src/Components/SelectGroup/SelectGroup.scss
@@ -45,6 +45,20 @@ $select-group--padding: $cf-marg-a;
   justify-content: center;
   align-items: center;
   @extend %type-uppercase;
+  position:relative;
+
+  &:after {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    content: '';
+    border-radius: $cf-radius;
+    transition: opacity $cf-transition-default;
+    opacity: 0;
+    background-color: #ffffff;
+  }
 
   &:last-child {
     margin-right: 0;
@@ -55,6 +69,9 @@ $select-group--padding: $cf-marg-a;
     background-color: $g6-smoke;
     color: $g18-cloud;
     cursor: pointer;
+    &:after {
+      opacity: $cf-hover-active-opacity;
+    }
   }
 
   &:focus {

--- a/src/Styles/variables.scss
+++ b/src/Styles/variables.scss
@@ -97,6 +97,13 @@ $c-galaxy: #9394ff;
 $c-pulsar: #513cc6;
 
 /*
+  State change variables
+*/
+
+$cf-hover-active-opacity: 0.08;
+$cf-disabled-opacity: 0.5;
+
+/*
    Z Variables
    -----------------------------------------------------------------------------
    Might not actually need any of these yet

--- a/src/Styles/variables.scss
+++ b/src/Styles/variables.scss
@@ -411,6 +411,20 @@ $cf-tree-nav__toggle-icon-hover: $g13-mist;
    -----------------------------------------------------------------------------
 */
 
+@mixin createOverlayBase() {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    content: '';
+    border-radius: $cf-radius;
+    transition: opacity $cf-transition-default;
+    opacity: 0;
+    background-color: #ffffff;
+}
+
+
 @mixin gradient-v($startColor, $endColor) {
   background: $startColor;
   background: -moz-linear-gradient(top, $startColor 0%, $endColor 100%);


### PR DESCRIPTION
I created tokens for opacity (Disabled and hover/active)
I've added the overlay effect to components that have hover/active state color changes like button and such.
I feel like there's a neater way to do this instead of coyping and pasting the following to every component lol:

&:after {
    position: absolute;
    top: 0;
    left: 0;
    width: 100%;
    height: 100%;
    content: '';
    z-index: -1;
    border-radius: $cf-radius;
    transition: opacity $cf-transition-default;
    opacity: 0;
    background-color: #ffffff;
  }
 
  Certainly if we were using CSS in JS, we could do something neater. 
  
  I think we can also use this pattern we use in labels too https://github.com/influxdata/clockface/blob/master/src/Utils/index.ts#L108-L130 
  but for now, this should help us get the hover stuff in control a little bit

Closes #

### Changes

// Describe what you changed

### Screenshots

// Add screenshots here if relevant

### Checklist
Check all that apply

- [ ] Updated documentation to reflect changes
- [ ] Added entry to top of Changelog with link to PR (not issue)
- [ ] Tests pass
- [ ] Peer reviewed and approved
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
